### PR TITLE
Only binds indicators once

### DIFF
--- a/lib/slider.js
+++ b/lib/slider.js
@@ -38,6 +38,10 @@
         this.start();
       }
 
+      if (this.indicators && this.indicatorClick) {
+        this.el.find(this.indicators).on('click', this.proxy(this.indicatorClicked));
+      }
+
       this.updatePreview();
     },
 
@@ -86,9 +90,6 @@
         var indicators = this.el.find(this.indicators);
         indicators.removeClass(this.indicatorClass);
         indicators.eq(this.currentPage - 1).addClass(this.indicatorClass);
-        if (this.indicatorClick) {
-          indicators.on('click', this.proxy(this.indicatorClicked));
-        }
       }
     },
 


### PR DESCRIPTION
Fixes an issue where indicators were bound to click each time go() was called.
